### PR TITLE
fix lb security groups

### DIFF
--- a/infrastructure/modules/app-cluster/load_balancer.tf
+++ b/infrastructure/modules/app-cluster/load_balancer.tf
@@ -5,7 +5,7 @@ resource "aws_alb" "application_load_balancer" {
   internal                   = false
   load_balancer_type         = "application"
   subnets                    = var.public_subnet_ids_list
-  security_groups            = [aws_security_group.load_balancer_security_group.id]
+  security_groups            = [aws_security_group.load_balancer_security_group_http.id, aws_security_group.load_balancer_security_group_https.id]
   drop_invalid_header_fields = true
   enable_deletion_protection = true
 
@@ -64,7 +64,7 @@ POLICY
 data "aws_ec2_managed_prefix_list" "cloudwatch" {
   name = "com.amazonaws.global.cloudfront.origin-facing"
 }
-resource "aws_security_group" "load_balancer_security_group" {
+resource "aws_security_group" "load_balancer_security_group_http" {
   # checkov:skip=CKV_AWS_260: Limits by prefix list ID's
   vpc_id      = var.vpc_id
   description = "ALB Security Group"
@@ -75,13 +75,6 @@ resource "aws_security_group" "load_balancer_security_group" {
     prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudwatch.id]
     description     = "Allow HTTP ingress"
   }
-  ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudwatch.id]
-    description     = "Allow HTTPS ingress"
-  }
   egress {
     from_port        = 0
     to_port          = 0
@@ -89,6 +82,23 @@ resource "aws_security_group" "load_balancer_security_group" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
     description      = "Allow all egress"
+  }
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "aws_security_group" "load_balancer_security_group_https" {
+  # checkov:skip=CKV_AWS_260: Limits by prefix list ID's
+  vpc_id      = var.vpc_id
+  description = "ALB Security Group"
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    prefix_list_ids = [data.aws_ec2_managed_prefix_list.cloudwatch.id]
+    description     = "Allow HTTPS ingress"
   }
   tags = var.tags
 

--- a/infrastructure/modules/app-cluster/main.tf
+++ b/infrastructure/modules/app-cluster/main.tf
@@ -356,7 +356,8 @@ resource "aws_ecs_service" "aws-ecs-service" {
     assign_public_ip = false
     security_groups = [
       aws_security_group.service_security_group.id,
-      aws_security_group.load_balancer_security_group.id
+      aws_security_group.load_balancer_security_group_http.id,
+      aws_security_group.load_balancer_security_group_https.id
     ]
   }
 
@@ -376,7 +377,7 @@ resource "aws_security_group" "service_security_group" {
     from_port       = 0
     to_port         = 0
     protocol        = "-1"
-    security_groups = [aws_security_group.load_balancer_security_group.id]
+    security_groups = [aws_security_group.load_balancer_security_group_http.id, aws_security_group.load_balancer_security_group_https.id]
     description     = "Allow traffic from load balancer"
   }
 


### PR DESCRIPTION
Cloudfront IPs number is too high to create one security group for lb. I created two security groups, one for http and one for https traffic. 
I deployed infrastructure from my branch and there was no issues.