### PR TITLE
/oauth endpoint using form encoded data instead of json

### DIFF
--- a/sdk/rapid/auth.py
+++ b/sdk/rapid/auth.py
@@ -59,7 +59,7 @@ class RapidAuth:
             self.url + "/oauth2/token",
             auth=self.credentials_secret(),
             headers=self.headers,
-            json=self.payload,
+            data=self.payload,
             timeout=TIMEOUT_PERIOD,
         )
         return response

--- a/sdk/rapid/rapid.py
+++ b/sdk/rapid/rapid.py
@@ -3,7 +3,7 @@ import time
 import requests
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import pandas as pd
 
@@ -336,7 +336,7 @@ class Rapid:
             return data
         raise SchemaUpdateFailedException("Could not update schema", data)
 
-    def create_client(self, client_name: str, client_permissions: list[str]):
+    def create_client(self, client_name: str, client_permissions: List[str]):
         """
         Creates a new client on the API with the specified permissions.
 
@@ -390,7 +390,7 @@ class Rapid:
             f"Failed to delete client with id: {client_id}, ensure it exists."
         )
 
-    def update_subject_permissions(self, subject_id: str, permissions: list[str]):
+    def update_subject_permissions(self, subject_id: str, permissions: List[str]):
         """
         Updates the permissions of a subject on the API.
 

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from rapid import Rapid, RapidAuth
 
+from typing import Tuple
+
 
 load_dotenv()
 
@@ -20,6 +22,16 @@ def rapid_auth(requests_mock) -> RapidAuth:
     return RapidAuth(
         url=RAPID_URL, client_id=RAPID_CLIENT_ID, client_secret=RAPID_CLIENT_SECRET
     )
+
+# Duplicate instance of the rapid_auth fixture also returns the request mock to be able to check the request
+# properties in unit tests.
+@pytest.fixture
+def rapid_auth_and_mocks(requests_mock) -> Tuple[RapidAuth, any]:
+    requests_mock.post(f"{RAPID_URL}/oauth2/token", json={"access_token": RAPID_TOKEN})
+    rapid_auth = RapidAuth(
+        url=RAPID_URL, client_id=RAPID_CLIENT_ID, client_secret=RAPID_CLIENT_SECRET
+    )
+    return (rapid_auth , requests_mock)
 
 
 @pytest.fixture

--- a/sdk/tests/test_auth.py
+++ b/sdk/tests/test_auth.py
@@ -3,6 +3,8 @@ import json
 from mock import Mock
 import pytest
 
+from typing import Tuple
+
 from rapid import RapidAuth
 from rapid.exceptions import AuthenticationErrorException, CannotFindCredentialException
 
@@ -43,10 +45,22 @@ class TestAuth:
             rapid_auth.validate_credentials()
             rapid_auth.request_token.assert_called_once()
 
-    def test_fetch_token(self, rapid_auth: RapidAuth):
+    def test_fetch_token(self, rapid_auth_and_mocks: Tuple[RapidAuth, any]):
+        [rapid_auth, mocks] = rapid_auth_and_mocks
         mocked_response = MockRequestResponse(
             content=json.dumps({"access_token": "token"}).encode("utf-8")
         )
         rapid_auth.request_token = Mock(return_value=mocked_response)
         res = rapid_auth.fetch_token()
+
         assert res == "token"
+
+        # Double check that the body of the request is in the right format.
+        assert mocks.called == True
+
+        token_request = mocks.request_history[0]
+
+        assert token_request.url == "https://test_domain/api/oauth2/token"
+        assert (
+            token_request.body == "grant_type=client_credentials&client_id=1234567890"
+        )


### PR DESCRIPTION
Hi team,

Spotted this while working on getting the lambda communicating with rAPId, the call is with the payload as json but the headers specify form encoded.

Any questions, please let me know.

Many thanks
Toby