### PR TITLE
update CloudFront Lambda@Edge regex patterns for dynamic routes

### DIFF
--- a/ui/lambda/lambda.js
+++ b/ui/lambda/lambda.js
@@ -8,16 +8,16 @@ exports.handler = function (event, _, callback) {
   // Handle dynamic routes
   const dynamicRoutes = {
     '/catalog/[search].html': /\/catalog\/[0-9a-zA-Z]/,
-    '/data/download/[domain]/[dataset].html': /\/data\/download\/[^/]+\/[^/]+/,
-    '/subject/modify/[subjectId].html': /\/subject\/modify\/[0-9]+/,
-    '/subject/modify/success/[subjectId].html': /\/subject\/modify\/success\/[0-9]+/,
-    '/tasks/[jobId].html': /\/tasks\/[0-9]+/
+    '/data/download/[layer]/[domain]/[dataset].html': /\/data\/download\/[^/]+\/[^/]+\/[^/]+/,
+    '/subject/modify/[subjectId].html': /\/subject\/modify\/[^/]+/,
+    '/subject/modify/success/[subjectId].html': /\/subject\/modify\/success\/[^/]+/,
+    '/tasks/[jobId].html': /\/tasks\/[^/]+/
   }
   if (uri && !uri.endsWith('.js')) {
     let found = false
     Object.keys(dynamicRoutes).forEach((key) => {
       const value = dynamicRoutes[key]
-      const isDynamicRouteMatch = value.test(uri)
+      const isDynamicRouteMatch = value.test(uri)  
       if (isDynamicRouteMatch) {
         request.uri = key
         found = true


### PR DESCRIPTION
**Bug**

Every so often, when navigating on rapid UI, there are no such key errors. 

To reproduce:
1. Create a failed upload job
2. immediately navigate to job id
![image](https://github.com/user-attachments/assets/34993af9-88c1-4a99-9d84-523a3d785795)

**Solution**

navigating internal links, via next.js works as intended. navigating URL directly makes a HTTP request to cloudfront which goes through lambda edge function. the regex was incorrect and only worked with job id's that began with numbers and not letters (hence intermittent) 