### PR TITLE
Enable DynamoDB deletion protection (EN-1329)

### DIFF
--- a/infrastructure/modules/app-cluster/db.tf
+++ b/infrastructure/modules/app-cluster/db.tf
@@ -6,7 +6,8 @@ resource "aws_dynamodb_table" "service_table" {
   name         = "${var.resource-name-prefix}_service_table"
   hash_key     = "PK"
   range_key    = "SK"
-  billing_mode = "PAY_PER_REQUEST"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
 
   attribute {
     name = "PK"

--- a/infrastructure/modules/auth/db.tf
+++ b/infrastructure/modules/auth/db.tf
@@ -6,7 +6,8 @@ resource "aws_dynamodb_table" "permissions_table" {
   name         = "${var.resource-name-prefix}_${var.permissions_table_name}"
   hash_key     = "PK"
   range_key    = "SK"
-  billing_mode = "PAY_PER_REQUEST"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
 
   attribute {
     name = "PK"

--- a/infrastructure/modules/data-workflow/dynamodb.tf
+++ b/infrastructure/modules/data-workflow/dynamodb.tf
@@ -3,7 +3,9 @@ resource "aws_dynamodb_table" "schema_table" {
   name         = "${var.resource-name-prefix}_schema_table"
   hash_key     = "PK"
   range_key    = "SK"
-  billing_mode = "PAY_PER_REQUEST"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
+
   attribute {
     name = "PK"
     type = "S"


### PR DESCRIPTION
## Summary
- Adds `deletion_protection_enabled = true` to all three DynamoDB tables (`service_table`, `schema_table`, `permissions_table`)
- No state mv required — in-place update
- Tables already have deletion protection enabled in ten-ds AWS account via CLI, this brings Terraform into sync